### PR TITLE
important change to sony news to get specifically video game news

### DIFF
--- a/client/src/components/MainContentComponents/NewsComponents/NewsLarge.js
+++ b/client/src/components/MainContentComponents/NewsComponents/NewsLarge.js
@@ -17,6 +17,7 @@ class NewsLarge extends Component {
     }
   }
   axiosCall(data) {
+    if (data === "Sony") data = "Sony Interactive Entertainment";
     axios({
       url:
         "https://contextualwebsearch-websearch-v1.p.rapidapi.com/api/Search/NewsSearchAPI?autoCorrect=true&pageNumber=1&pageSize=10&q=" +


### PR DESCRIPTION
we were getting sony news for speakers, and football players with the name sony. This makes sure that we are searching for sony interactive entertainment.